### PR TITLE
SDL 2 support (dropping SDL 1.2 support)

### DIFF
--- a/sfxr/.gitignore
+++ b/sfxr/.gitignore
@@ -1,0 +1,17 @@
+sfxr
+*.o
+.deps/
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+compile
+config.h
+config.in
+config.log
+config.status
+configure
+depcomp
+install-sh
+missing
+stamp-h1

--- a/sfxr/Makefile.am
+++ b/sfxr/Makefile.am
@@ -1,9 +1,9 @@
 AUTOMAKE_OPTIONS = foreign
 
-CFLAGS = --pedantic -Wall -O2
-CXXFLAGS=$(CFLAGS) `sdl-config --cflags`
+CFLAGS = --pedantic -Wall -O2 -g
+CXXFLAGS=$(CFLAGS) `sdl2-config --cflags`
 CPPFLAGS=-DDATADIR='$(pkgdatadir)'
-LDFLAGS=`sdl-config --libs`
+LDFLAGS=`sdl2-config --libs`
 
 bin_PROGRAMS = sfxr
 

--- a/sfxr/configure.ac
+++ b/sfxr/configure.ac
@@ -2,8 +2,8 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.64])
-AC_INIT([sfxr], [1.2.0], [grimfang4@gmail.com],[sfxr-1.2.0.tar],[http://code.google.com/p/sfxr])
-AM_INIT_AUTOMAKE(sfxr, 1.2.0)
+AC_INIT([sfxr], [1.3.0], [grimfang4@gmail.com],[sfxr-1.3.0.tar],[https://github.com/grimfang4/sfxr])
+AM_INIT_AUTOMAKE(sfxr, 1.3.0)
 AM_CONFIG_HEADER(config.h:config.in)
 
 AC_CONFIG_SRCDIR([source/sdlkit.h])
@@ -19,8 +19,8 @@ AC_PROG_INSTALL
 # Checks for header files.
 AC_CHECK_HEADERS([malloc.h stdlib.h string.h])
 
-AC_CHECK_LIB(SDL, SDL_Init, [], [
-        echo "**Error** libSDL was not found."
+AC_CHECK_LIB(SDL2, SDL_Init, [], [
+        echo "**Error** libSDL2 was not found."
         exit -1
         ])
 

--- a/sfxr/source/main.cpp
+++ b/sfxr/source/main.cpp
@@ -183,7 +183,7 @@ void ResetParams()
 	p_lpf_ramp=0.0f;
 	p_hpf_freq=0.0f;
 	p_hpf_ramp=0.0f;
-	
+
 	p_pha_offset=0.0f;
 	p_pha_ramp=0.0f;
 
@@ -199,7 +199,7 @@ bool LoadSettings(char* filename)
 	FILE* file=fopen(filename, "rb");
 	if(!file)
 		return false;
-	
+
 	size_t n;
 	(void)n;
 	int version=0;
@@ -236,7 +236,7 @@ bool LoadSettings(char* filename)
 	n = fread(&p_lpf_ramp, 1, sizeof(float), file);
 	n = fread(&p_hpf_freq, 1, sizeof(float), file);
 	n = fread(&p_hpf_ramp, 1, sizeof(float), file);
-	
+
 	n = fread(&p_pha_offset, 1, sizeof(float), file);
 	n = fread(&p_pha_ramp, 1, sizeof(float), file);
 
@@ -287,7 +287,7 @@ bool SaveSettings(char* filename)
 	fwrite(&p_lpf_ramp, 1, sizeof(float), file);
 	fwrite(&p_hpf_freq, 1, sizeof(float), file);
 	fwrite(&p_hpf_ramp, 1, sizeof(float), file);
-	
+
 	fwrite(&p_pha_offset, 1, sizeof(float), file);
 	fwrite(&p_pha_ramp, 1, sizeof(float), file);
 
@@ -407,7 +407,7 @@ void SynthSample(int length, float* buffer, FILE* file)
 		if(period<8) period=8;
 		square_duty+=square_slide;
 		if(square_duty<0.0f) square_duty=0.0f;
-		if(square_duty>0.5f) square_duty=0.5f;		
+		if(square_duty>0.5f) square_duty=0.5f;
 		// volume envelope
 		env_time++;
 		if(env_time>env_length[env_stage])
@@ -546,7 +546,7 @@ static void SDLAudioCallback(void *userdata, Uint8 *stream, int len)
 	{
 		unsigned int l = len/2;
 		float* fbuf = new float[l];
-		memset(fbuf, 0, sizeof(fbuf));
+		memset(fbuf, 0, sizeof(float) * l);
 		SynthSample(l, fbuf, NULL);
 		while (l--)
 		{
@@ -613,7 +613,7 @@ bool ExportWAV(const char* filename)
 	dword=file_sampleswritten*wav_bits/8;
 	fwrite(&dword, 1, 4, foutput); // chunk size (data)
 	fclose(foutput);
-	
+
 	return true;
 }
 
@@ -951,7 +951,7 @@ void DrawScreen()
 	DrawBar(110, 0, 2, 480, 0x000000);
 	DrawText(font, 120, 10, 0x504030, "MANUAL SETTINGS");
 	DrawSprite(ld48, 8, 440, 0, 0xB0A080);
-	
+
 
 	bool do_play=false;
 
@@ -1120,9 +1120,9 @@ void DrawScreen()
 	int xpos=350;
 
 	DrawBar(xpos-190, ypos*18-5, 300, 2, 0x0000000);
-	
+
 	float oldValue = 0;
-	
+
 	oldValue = p_env_attack;
 	if(Slider(xpos, (ypos++)*18, p_env_attack, false, "ATTACK TIME"))
 	{

--- a/sfxr/source/sdlkit.cpp
+++ b/sfxr/source/sdlkit.cpp
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <set>
 
 void error (const char *file, unsigned int line, const char *msg)
 {
@@ -32,24 +33,37 @@ void error (const char *file, unsigned int line, const char *msg)
 	exit(1);
 }
 
+std::set< bool > keys;
 
-bool keys[SDLK_LAST];
-
-bool DPInput::KeyPressed(SDLKey key)
+bool DPInput::KeyPressed(SDL_Keycode key)
 {
-	bool r = keys[key];
-	keys[key] = false;
+	bool r = keys.find(key) != keys.end ();
+	keys.erase(key);
 	return r;
 }
 
 Uint32 *ddkscreen32;
-Uint16 *ddkscreen16;
 int ddkpitch;
 int mouse_x, mouse_y, mouse_px, mouse_py;
 bool mouse_left = false, mouse_right = false, mouse_middle = false;
 bool mouse_leftclick = false, mouse_rightclick = false, mouse_middleclick = false;
 
+SDL_Window *sdlwindow = NULL;
+SDL_Renderer *sdlrenderer = NULL;
 SDL_Surface *sdlscreen = NULL;
+
+static void sdlflip() {
+
+	SDL_Texture *sdltexture = SDL_CreateTextureFromSurface(sdlrenderer, sdlscreen);
+	if (!sdltexture) return;
+
+    SDL_SetRenderDrawColor(sdlrenderer, 0x00, 0x00, 0x00, 0x00);
+    SDL_RenderClear(sdlrenderer);
+    SDL_RenderCopy(sdlrenderer, sdltexture, NULL, NULL);
+    SDL_RenderPresent(sdlrenderer);
+
+    SDL_DestroyTexture(sdltexture);
+}
 
 void sdlupdate ()
 {
@@ -75,7 +89,6 @@ bool ddkLock ()
 			return false;
 	}
 	ddkpitch = sdlscreen->pitch / (sdlscreen->format->BitsPerPixel == 32 ? 4 : 2);
-	ddkscreen16 = (Uint16*)(sdlscreen->pixels);
 	ddkscreen32 = (Uint32*)(sdlscreen->pixels);
 	return true;
 }
@@ -90,8 +103,9 @@ void ddkUnlock ()
 
 void ddkSetMode (int width, int height, int bpp, int refreshrate, int fullscreen, const char *title)
 {
-	VERIFY(sdlscreen = SDL_SetVideoMode(width, height, bpp, fullscreen ? SDL_FULLSCREEN : 0));
-	SDL_WM_SetCaption(title, title);
+	VERIFY(0 == SDL_CreateWindowAndRenderer(width, height, fullscreen ? SDL_WINDOW_FULLSCREEN : 0, &sdlwindow, &sdlrenderer));
+	VERIFY(sdlscreen = SDL_CreateRGBSurface(0, width, height, bpp, 0, 0, 0, 0));
+	SDL_SetWindowTitle (sdlwindow, title);
 }
 
 #include <string.h>
@@ -121,10 +135,10 @@ std::list<std::string> ioList(const std::string& dirname, bool directories, bool
 	using namespace std;
     list<string> dirList;
     list<string> fileList;
-    
+
     DIR* dir = opendir(dirname.c_str());
     dirent* entry;
-    
+
     while ((entry = readdir(dir)) != NULL)
     {
         #ifdef WIN32
@@ -139,15 +153,15 @@ std::list<std::string> ioList(const std::string& dirname, bool directories, bool
         else if(files)
             fileList.push_back(entry->d_name);
     }
- 
+
     closedir(dir);
-    
+
     dirList.sort();
     fileList.sort();
-    
+
     fileList.splice(fileList.begin(), dirList);
-    
-    
+
+
     return fileList;
 }
 
@@ -167,7 +181,7 @@ std::string stoupper(const std::string& s)
 	std::string result = s;
 	std::string::iterator i = result.begin();
 	std::string::iterator end = result.end();
-	
+
 	while(i != end)
 	{
 		*i = std::toupper((unsigned char)*i);
@@ -179,14 +193,15 @@ std::string stoupper(const std::string& s)
 
 bool ioExists(const std::string& filename)
 {
-    return (access(filename.c_str(), 0) == 0);
+    struct stat FileStat;
+    return (0 == stat (filename.c_str (), &FileStat));
 }
 
 bool ioNew(const std::string& filename, bool readable, bool writeable)
 {
     if(ioExists(filename))
         return false;
-    
+
     FILE* file = fopen(filename.c_str(), "wb");
     if(file == NULL)
         return false;
@@ -205,11 +220,9 @@ extern Spriteset font;
 std::string new_file(const std::string& forced_extension)
 {
 	using namespace std;
-	SDL_EnableUNICODE(1);
-	SDL_EnableKeyRepeat(0, 0);
-	
+
 	string result;
-	
+
 	bool done = false;
 	SDL_Event e;
 	while (!done)
@@ -220,7 +233,7 @@ std::string new_file(const std::string& forced_extension)
 			{
 				case SDL_QUIT:
 					exit(0);
-		
+
 				case SDL_KEYDOWN:
 					if(e.key.keysym.sym == SDLK_ESCAPE)
 					{
@@ -231,37 +244,33 @@ std::string new_file(const std::string& forced_extension)
 						done = true;
 						break;
 					}
-					
-					{
-						char c = e.key.keysym.unicode;
-						if(0x21 <= c && c <= 0x7E)
-							result += c;
-					}
-		
+					break;
+
+				case SDL_TEXTINPUT:
+					result += e.text.text;
+					break;
+
 				default: break;
 			}
 		}
 		sdlupdate();
-		
+
 		ClearScreen(0xC0B090);
-		
+
 		DrawText(font, 90, 150, 0x000000, "TYPE NEW FILE NAME:");
 		DrawText(font, 100, 200, 0x000000, "%s", stoupper(result).c_str());
 
 		SDL_Delay(5);
-		
-		SDL_Flip(sdlscreen);
+
+		sdlflip();
 	}
-	
-	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
-	SDL_EnableUNICODE(0);
-	
+
 	//if(result.size() == 0)
 	//	throw runtime_error("New file name is empty string.");
-	
+
 	if(result.size() < 6 || result.substr(result.size()-1 - 4, string::npos) != forced_extension)
 		result += forced_extension;
-	
+
 	return result;
 }
 
@@ -273,7 +282,7 @@ void DrawFileSelectScreen(std::list<std::string>& files, char* buf, bool& gotFil
 
 	ClearScreen(0xC0B090);
 
-	
+
 	int i = 0, j = 0;
 	for(list<string>::iterator e = files.begin(); e != files.end(); e++)
 	{
@@ -290,13 +299,13 @@ void DrawFileSelectScreen(std::list<std::string>& files, char* buf, bool& gotFil
 		}
 		i++;
 	}
-	
+
 	if(Button(10, 10, false, "CANCEL", 400))
 	{
 		gotFile = false;
 		done = true;
 	}
-	
+
 	if(showNewButton && Button(120, 10, false, "NEW FILE", 401))
 	{
 		string s = new_file(".sfxr");
@@ -304,7 +313,7 @@ void DrawFileSelectScreen(std::list<std::string>& files, char* buf, bool& gotFil
 		{
 			ioNew(s, true, true);
 			files = ioList(".", false, true);
-			
+
 			for(list<string>::iterator e = files.begin(); e != files.end();)
 			{
 				if(e->find(".sfxr") == string::npos)
@@ -312,7 +321,7 @@ void DrawFileSelectScreen(std::list<std::string>& files, char* buf, bool& gotFil
 					e = files.erase(e);
 					continue;
 				}
-				
+
 				e++;
 			}
 		}
@@ -328,12 +337,12 @@ void DrawFileSelectScreen(std::list<std::string>& files, char* buf, bool& gotFil
 bool select_file (char *buf, bool showNewButton)
 {
 	// FIXME: Needs directory browsing
-	
+
 	bool gotFile = false;
 	using namespace std;
 	list<string> files;
 	files = ioList(".", false, true);
-	
+
 	for(list<string>::iterator e = files.begin(); e != files.end();)
 	{
 		if(e->find(".sfxr") == string::npos)
@@ -341,10 +350,10 @@ bool select_file (char *buf, bool showNewButton)
 			e = files.erase(e);
 			continue;
 		}
-		
+
 		e++;
 	}
-	
+
 	bool done = false;
 	SDL_Event e;
 	while (!done)
@@ -354,19 +363,19 @@ bool select_file (char *buf, bool showNewButton)
 		{
 			case SDL_QUIT:
 				exit(0);
-	
+
 			case SDL_KEYDOWN:
-				keys[e.key.keysym.sym] = true;
-	
+				keys.insert(e.key.keysym.sym);
+
 			default: break;
 		}
 		sdlupdate();
-		
+
 		DrawFileSelectScreen(files, buf, gotFile, done, showNewButton);
 
 		SDL_Delay(5);
-		
-		SDL_Flip(sdlscreen);
+
+		sdlflip();
 	}
 	return gotFile;
 }
@@ -385,9 +394,9 @@ void sdlinit ()
 	if (!icon)
 		icon = SDL_LoadBMP("images/sfxr.bmp");
 	if (icon)
-		SDL_WM_SetIcon(icon, NULL);
+		SDL_SetWindowIcon(sdlwindow, icon);
 	atexit(sdlquit);
-	memset(keys, 0, sizeof(keys));
+	keys.clear();
 	ddkInit();
 }
 
@@ -401,16 +410,16 @@ void loop (void)
 		{
 			case SDL_QUIT:
 				exit(0);
-	
+
 			case SDL_KEYDOWN:
-				keys[e.key.keysym.sym] = true;
-	
+				keys.insert(e.key.keysym.sym);
+
 			default: break;
 		}
 		sdlupdate();
 		if (!ddkCalcFrame())
 			return;
-		SDL_Flip(sdlscreen);
+		sdlflip();
 	}
 }
 

--- a/sfxr/source/sdlkit.cpp
+++ b/sfxr/source/sdlkit.cpp
@@ -22,7 +22,6 @@
 
 #include "sdlkit.h"
 
-
 #include <stdio.h>
 #include <string.h>
 #include <set>
@@ -33,11 +32,11 @@ void error (const char *file, unsigned int line, const char *msg)
 	exit(1);
 }
 
-std::set< bool > keys;
+std::set< unsigned int > keys;
 
 bool DPInput::KeyPressed(SDL_Keycode key)
 {
-	bool r = keys.find(key) != keys.end ();
+	bool r = (keys.find(key) != keys.end());
 	keys.erase(key);
 	return r;
 }
@@ -413,6 +412,7 @@ void loop (void)
 
 			case SDL_KEYDOWN:
 				keys.insert(e.key.keysym.sym);
+				break;
 
 			default: break;
 		}

--- a/sfxr/source/sdlkit.h
+++ b/sfxr/source/sdlkit.h
@@ -40,7 +40,6 @@ typedef Uint16 WORD;
 
 
 extern Uint32 *ddkscreen32;
-extern Uint16 *ddkscreen16;
 extern int ddkpitch;
 
 
@@ -61,7 +60,7 @@ public:
 	~DPInput() {}
 	static void Update () {}
 
-	static bool KeyPressed(SDLKey key);
+	static bool KeyPressed(SDL_Keycode key);
 
 };
 


### PR DESCRIPTION
Hi! I use sfxr in some projects, and I have some additions + hacks that I use locally. In particular, I have a commandline feature that lets me use sfxr in build pipelines to render audio.

I wanted to PR these changes so they can live on properly, but when I went and looked at things I realized sfxr was still tied to SDL 1.2 (I think my build pipeline has just been using a pre-built binary.) So first things first I thought I would PR a change to bring it up to SDL 2.0.

There is also an audio buffer initialization bugfix, and I created a `.gitignore` file.

This builds and seems to work fine on Ubuntu 20. I'll do some builds + testing on macOS and Windows.

TODO:
- [ ] test the file saving/loading (.wav and .sfxr)
- [ ] build/test on windows
- [ ] build/test on macOS